### PR TITLE
 Adding the ability to filter rasters with mod ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 /bin/
 /build/
 /eclipse/
+*.iml
+*.ipr
+*.iws
+/run
+/out

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "3.0"
+version = "3.1"
 group = "mrtjp.rasterdevice" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "RasterDevice"
 

--- a/src/main/java/mrtjp/rasterdevice/GuiFactory.java
+++ b/src/main/java/mrtjp/rasterdevice/GuiFactory.java
@@ -75,26 +75,30 @@ public class GuiFactory implements IModGuiFactory
         }
 
         @Override
-        protected void mouseClicked(int x, int y, int mouseEvent) {
+        protected void mouseClicked(int x, int y, int mouseEvent)
+        {
             super.mouseClicked(x, y, mouseEvent);
             text.mouseClicked(x, y, mouseEvent);
         }
 
         @Override
-        public void updateScreen() {
+        public void updateScreen()
+        {
             super.updateScreen();
             text.updateCursorCounter();
         }
 
         @Override
-        protected void keyTyped(char eventChar, int eventKey) {
+        protected void keyTyped(char eventChar, int eventKey)
+        {
             super.keyTyped(eventChar, eventKey);
             if (text.textboxKeyTyped(eventChar, eventKey))
                 RasterDeviceMod.instance.MOD_ID_TO_RASTER = text.getText();
         }
 
         @Override
-        public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+        public void drawScreen(int mouseX, int mouseY, float partialTicks)
+        {
             super.drawScreen(mouseX, mouseY, partialTicks);
             Minecraft.getMinecraft().fontRenderer.drawString("Mod ID to Raster:", this.width/2-(65/2)+80,
                     this.height/5+(int)Math.floor(2.5*25), Color.WHITE.getRGB());

--- a/src/main/java/mrtjp/rasterdevice/GuiFactory.java
+++ b/src/main/java/mrtjp/rasterdevice/GuiFactory.java
@@ -7,7 +7,9 @@ import cpw.mods.fml.client.config.IConfigElement;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.GuiTextField;
 
+import java.awt.*;
 import java.util.ArrayList;
 import java.util.Set;
 
@@ -17,6 +19,8 @@ public class GuiFactory implements IModGuiFactory
 {
     public static class FMLConfigGuiScreen extends GuiConfig
     {
+
+        private GuiTextField text;
 
         public FMLConfigGuiScreen(GuiScreen parent)
         {
@@ -65,6 +69,36 @@ public class GuiFactory implements IModGuiFactory
 
             this.buttonList.add(new GuiUnicodeGlyphButton(3333, this.width/2-(65/2)+80,
                     this.height/dy+4*25, 80, 20, "Render all", RESET_CHAR, 2.0F));
+            text = new GuiTextField(Minecraft.getMinecraft().fontRenderer, this.width/2-(65/2)+80,
+                    this.height/dy+3*25, 80, 20);
+            text.setText(RasterDeviceMod.instance.MOD_ID_TO_RASTER);
+        }
+
+        @Override
+        protected void mouseClicked(int x, int y, int mouseEvent) {
+            super.mouseClicked(x, y, mouseEvent);
+            text.mouseClicked(x, y, mouseEvent);
+        }
+
+        @Override
+        public void updateScreen() {
+            super.updateScreen();
+            text.updateCursorCounter();
+        }
+
+        @Override
+        protected void keyTyped(char eventChar, int eventKey) {
+            super.keyTyped(eventChar, eventKey);
+            if (text.textboxKeyTyped(eventChar, eventKey))
+                RasterDeviceMod.instance.MOD_ID_TO_RASTER = text.getText();
+        }
+
+        @Override
+        public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+            super.drawScreen(mouseX, mouseY, partialTicks);
+            Minecraft.getMinecraft().fontRenderer.drawString("Mod ID to Raster:", this.width/2-(65/2)+80,
+                    this.height/5+(int)Math.floor(2.5*25), Color.WHITE.getRGB());
+            text.drawTextBox();
         }
     }
 

--- a/src/main/java/mrtjp/rasterdevice/RasterDeviceMod.java
+++ b/src/main/java/mrtjp/rasterdevice/RasterDeviceMod.java
@@ -13,6 +13,8 @@ public class RasterDeviceMod
     @Instance("RasterDevice")
     public static RasterDeviceMod instance;
 
+    public String MOD_ID_TO_RASTER = "all";
+
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event)
     {

--- a/src/main/java/mrtjp/rasterdevice/RasterJob.java
+++ b/src/main/java/mrtjp/rasterdevice/RasterJob.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -70,31 +71,38 @@ public class RasterJob
         {
             @SuppressWarnings("unchecked")
             Iterator<Item> it = GameData.getItemRegistry().iterator();
+
+            if (!RasterDeviceMod.instance.MOD_ID_TO_RASTER.equalsIgnoreCase("all"))
+                System.out.println("Rastering items from mod id(s): "+RasterDeviceMod.instance.MOD_ID_TO_RASTER);
+
             while (it.hasNext())
             {
                 Item item = it.next();
-
-                if (item == null) continue;
-                if (!isItemAllowed(item)) continue;
-
-                ArrayList<ItemStack> sub = new ArrayList<ItemStack>();
-                item.getSubItems(item, CreativeTabs.tabAllSearch, sub);
-
-                for (ItemStack stack : sub)
+                if (RasterDeviceMod.instance.MOD_ID_TO_RASTER.equalsIgnoreCase("all") || Arrays.asList(RasterDeviceMod.instance.MOD_ID_TO_RASTER.split(",")).contains(Item.itemRegistry.getNameForObject(item).split(":")[0]))
                 {
-                    System.out.println("Rastering " + item.getUnlocalizedName() + ":" + stack.getItemDamage() + " [" + getName(stack) + "]");
+                    if (item == null) continue;
+                    if (!isItemAllowed(item)) continue;
 
-                    try
+                    ArrayList<ItemStack> sub = new ArrayList<ItemStack>();
+                    item.getSubItems(item, CreativeTabs.tabAllSearch, sub);
+                    for (ItemStack stack : sub)
                     {
-                        if (doRaster(r, stack)) drawRasterToFile(folder, getName(stack));
-                    }
-                    catch (Throwable t)
-                    {
-                        System.err.println("RENDER FALIED: "+getName(stack));
-                        t.printStackTrace();
-                    }
 
-                    clearCanvas();
+                        System.out.println("Rastering "+item.getUnlocalizedName()+":"+stack.getItemDamage()+" ["+getName(stack)+"]");
+
+                        try
+                        {
+                            if (doRaster(r, stack))
+                                drawRasterToFile(folder, getName(stack));
+                        }
+                        catch (Throwable t)
+                        {
+                            System.err.println("RENDER FALIED: "+getName(stack));
+                            t.printStackTrace();
+                        }
+
+                        clearCanvas();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Enter ‘all’ to ignore mod ids or enter the mod id (case-sensitive), separate with commas if you wish to filter by multiple mod ids